### PR TITLE
Implement modal editing flow with permissions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -55,6 +55,7 @@
             
             <div class="user-controls">
                 <span id="userInfo" class="user-info"></span>
+                <button id="editActionBtn" class="btn btn-primary" style="display:none;">Edit</button>
                 <button id="logoutBtn" class="btn btn-secondary">Logout</button>
             </div>
         </header>
@@ -204,11 +205,16 @@
                     </div>
                     <div class="form-group">
                         <label for="uploadFile">Select File</label>
-                        <input type="file" id="uploadFile" name="file" required>
+                        <input type="file" id="uploadFile" name="file">
                         <small>Maximum file size: 10MB</small>
                     </div>
+                    <div class="form-group">
+                        <label for="embedLink">Embed link (optional)</label>
+                        <input type="url" id="embedLink" placeholder="https://docs.google.com/...">
+                        <small>Paste a Google Docs/Drive or other embeddable URL. If provided, file selection is optional.</small>
+                    </div>
                     <div class="form-actions">
-                        <button type="submit" class="btn btn-primary">Upload</button>
+                        <button type="submit" class="btn btn-primary">Save</button>
                         <button type="button" class="btn btn-secondary" onclick="closeModal('uploadModal')">Cancel</button>
                     </div>
                 </form>
@@ -225,6 +231,24 @@
             </div>
             <div class="modal-body">
                 <div id="revisionsList"></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Edit Options Modal -->
+    <div id="editOptionsModal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2>What would you like to do?</h2>
+                <span class="close" onclick="closeModal('editOptionsModal')">&times;</span>
+            </div>
+            <div class="modal-body">
+                <div class="option-grid" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;">
+                    <button id="optEditText" class="btn btn-primary">Write/Edit Text</button>
+                    <button id="optUploadImage" class="btn btn-secondary">Upload an Image</button>
+                    <button id="optEmbedDoc" class="btn btn-secondary">Embed a Document</button>
+                    <button id="optViewRevisions" class="btn">View Revisions</button>
+                </div>
             </div>
         </div>
     </div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -28,6 +28,9 @@ class App {
         // Setup keyboard shortcuts
         this.setupKeyboardShortcuts();
         
+        // Setup global Edit action
+        this.setupEditAction();
+        
         console.log('UWA Motorsport Wiki initialized successfully');
     }
 
@@ -172,6 +175,83 @@ class App {
                 }
             }
         });
+    }
+
+    setupEditAction() {
+        const editBtn = document.getElementById('editActionBtn');
+        if (!editBtn) return;
+
+        // Click opens options modal
+        editBtn.addEventListener('click', () => {
+            const modal = document.getElementById('editOptionsModal');
+            if (modal) modal.style.display = 'block';
+        });
+
+        // Wire option buttons
+        const optEditText = document.getElementById('optEditText');
+        const optUploadImage = document.getElementById('optUploadImage');
+        const optEmbedDoc = document.getElementById('optEmbedDoc');
+        const optViewRevisions = document.getElementById('optViewRevisions');
+
+        const getCurrentPage = () => (window.wiki ? window.wiki.getCurrentPage() : null);
+
+        if (optEditText) {
+            optEditText.addEventListener('click', () => {
+                const page = getCurrentPage();
+                if (!page) return;
+                // Open existing edit modal flow
+                if (window.wiki) window.wiki.editPage(page);
+                closeModal('editOptionsModal');
+            });
+        }
+
+        if (optUploadImage) {
+            optUploadImage.addEventListener('click', () => {
+                const page = getCurrentPage();
+                if (!page) return;
+                if (window.uploads) window.uploads.showUploadModal(page);
+                closeModal('editOptionsModal');
+            });
+        }
+
+        if (optEmbedDoc) {
+            optEmbedDoc.addEventListener('click', () => {
+                const page = getCurrentPage();
+                if (!page) return;
+                // Reuse upload modal but preset to document mode
+                const uploadType = document.getElementById('uploadType');
+                if (window.uploads) {
+                    window.uploads.showUploadModal(page);
+                    if (uploadType) {
+                        uploadType.value = 'document';
+                        if (typeof window.uploads.updateFileInputAccept === 'function') {
+                            window.uploads.updateFileInputAccept('document');
+                        }
+                    }
+                }
+                closeModal('editOptionsModal');
+            });
+        }
+
+        if (optViewRevisions) {
+            optViewRevisions.addEventListener('click', () => {
+                const page = getCurrentPage();
+                if (!page) return;
+                if (window.editor) window.editor.showRevisions(page);
+                closeModal('editOptionsModal');
+            });
+        }
+
+        // Initial visibility and on page change we may update it
+        this.updateEditButtonVisibility();
+    }
+
+    updateEditButtonVisibility() {
+        const editBtn = document.getElementById('editActionBtn');
+        if (!editBtn || !window.auth || !window.wiki) return;
+        const pageId = window.wiki.getCurrentPage();
+        const canEdit = pageId ? window.auth.canEditPage(pageId, window.auth.getCurrentRole(), window.auth.getCurrentSubteam()) : false;
+        editBtn.style.display = canEdit ? 'inline-block' : 'none';
     }
 
     // Utility methods

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -120,6 +120,11 @@ class Auth {
         
         // Update permissions
         this.updatePermissions();
+        
+        // Update Edit action visibility
+        if (window.app && typeof window.app.updateEditButtonVisibility === 'function') {
+            window.app.updateEditButtonVisibility();
+        }
     }
 
     clearCurrentUser() {
@@ -134,6 +139,11 @@ class Auth {
         
         // Reset permissions
         this.resetPermissions();
+        
+        // Update Edit action visibility
+        if (window.app && typeof window.app.updateEditButtonVisibility === 'function') {
+            window.app.updateEditButtonVisibility();
+        }
     }
 
     updatePermissions() {
@@ -142,6 +152,11 @@ class Auth {
         
         // Update navigation items based on role
         this.updateNavigationPermissions(role, subteam);
+        
+        // Update Edit action visibility for current page
+        if (window.app && typeof window.app.updateEditButtonVisibility === 'function') {
+            window.app.updateEditButtonVisibility();
+        }
     }
 
     updateNavigationPermissions(role, subteam) {

--- a/public/js/wiki.js
+++ b/public/js/wiki.js
@@ -149,16 +149,8 @@ class Wiki {
             </div>
         `;
 
-        // Add edit controls if user can edit
-        if (auth.canEditPage(pageId, auth.getCurrentRole(), auth.getCurrentSubteam())) {
-            content += `
-                <div class="edit-controls">
-                    <button class="btn btn-primary" onclick="wiki.editPage('${pageId}')">Edit Page</button>
-                    <button class="btn btn-secondary" onclick="wiki.showUploadModal('${pageId}')">Upload File</button>
-                    <button class="btn btn-secondary" onclick="wiki.showRevisions('${pageId}')">View Revisions</button>
-                </div>
-            `;
-        }
+        // Edit controls removed in favor of global Edit action and modal
+        // Intentionally left blank
 
         // Add page content
         if (pageData.content) {
@@ -198,6 +190,11 @@ class Wiki {
         }).catch(() => {
             contentArea.innerHTML = content;
         });
+        
+        // Update header Edit action visibility
+        if (window.app && typeof window.app.updateEditButtonVisibility === 'function') {
+            window.app.updateEditButtonVisibility();
+        }
     }
 
     generateTemplateContent(pageId) {


### PR DESCRIPTION
Refactor the editing workflow to a Confluence-style modal, improving UX with a clean default view and centralized edit actions.

---
<a href="https://cursor.com/background-agent?bcId=bc-5200a767-2629-4312-a50b-021e94493475">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5200a767-2629-4312-a50b-021e94493475">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

